### PR TITLE
fix a problem running for the first time when RP1210_selection.txt contains values that are invalid

### DIFF
--- a/RP1210Select.py
+++ b/RP1210Select.py
@@ -150,6 +150,8 @@ class SelectRP1210(QDialog):
         try:
             self.vendor_combo_box.setCurrentIndex(int(self.selection_index[0]))
         except:
+            self.selection_index = '0,0,0'.split(',')
+            self.vendor_combo_box.setCurrentIndex(int(self.selection_index[0]))
             pass
 
         if self.vendor_combo_box.count() > 0:
@@ -161,6 +163,10 @@ class SelectRP1210(QDialog):
         if self.rp1201_missing:
             return
         self.api_string = self.vendor_combo_box.currentText().split("-")[0].strip()
+        if self.api_string == '':
+            self.selection_index = '0,0,0'.split(',')
+            self.vendor_combo_box.setCurrentIndex(int(self.selection_index[0]))
+            self.api_string = self.vendor_combo_box.currentText().split("-")[0].strip()
         self.device_combo_box.clear()
         self.protocol_combo_box.clear()
         self.speed_combo_box.clear()


### PR DESCRIPTION
RP1210_selection.txt is committed with 1,1,0 so only valid on systems with 2x or more VDAs.